### PR TITLE
Fix speed assignment in normal mode

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -81,6 +81,7 @@ RegisterCommand(Config.StartCommand, function(source, args)
             Speed = Config.CrazySpeed
         elseif mode == 'normal' then
             Drive = Config.NormalDrive
+            Speed = Config.NormalSpeed                
         end
         if DoesBlipExist(GetFirstBlipInfoId(8)) then
             local blip = GetFirstBlipInfoId(8)


### PR DESCRIPTION
Current setup does not allow people to change speed from crazy to normal.
I have made the changes in my own city, and this fixes them. No issues arise.